### PR TITLE
Updated RuneLite version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.27'
+def runeLiteVersion = '1.9.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.kittentracker'
-version = '1.0-SNAPSHOT'
+version = '1.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
- Updated runeliteVersion to 1.9.2. This seems to "fix" some of the functionality that was not working (e.g. ball of wool not changing value) in RuneLite version 1.9.2.