### PR TITLE
Version Bump - 1.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.27'
+def runeLiteVersion = '1.9.3'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.kittentracker'
-version = '1.0-SNAPSHOT'
+version = '1.1.193'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
- Updated/tested general functionality with runeLiteVersion 1.9.3
- Changed version to '1.1.193'. There was some minor bug fixing, and this is to reflect it.
- Suggested versioning format: 'x.y' reflects major and minor changes, and '.abc' follows the RuneLite version.