### PR TITLE
Update Kitten Tracker to Properly Track Time as the In-Game Kitten Does

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.9.6'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/kittentracker/KittenAttentionType.java
+++ b/src/main/java/com/kittentracker/KittenAttentionType.java
@@ -23,6 +23,6 @@ public enum KittenAttentionType {
     }
 
     int getTimeBeforeKittenRunsAway() {
-        return attentionTime + KittenPlugin.ATTENTION_TIME_FROM_WARNING_TO_RUNNING_AWAY_IN_SECONDS;
+        return attentionTime + KittenPlugin.ATTENTION_FIRST_WARNING_TIME_LEFT_IN_SECONDS;
     }
 }

--- a/src/main/java/com/kittentracker/KittenConfig.java
+++ b/src/main/java/com/kittentracker/KittenConfig.java
@@ -86,6 +86,17 @@ public interface KittenConfig extends Config {
         return true;
     }
 
+
+    @ConfigItem(
+            keyName = "felineId",
+            name = "",
+            description = "",
+            hidden = true
+    )
+    default int felineId() {
+        return -1;
+    }
+
     @ConfigItem(
             keyName = "felineId",
             name = "",

--- a/src/main/java/com/kittentracker/KittenConfig.java
+++ b/src/main/java/com/kittentracker/KittenConfig.java
@@ -36,9 +36,7 @@ public interface KittenConfig extends Config {
             description = "Displays a countdown for your kitten to grow into a cat",
             position = 1
     )
-    default boolean kittenOverlay() {
-        return true;
-    }
+    default boolean kittenOverlay() { return true; }
 
     @ConfigItem(
             keyName = "catOverlay",
@@ -56,9 +54,7 @@ public interface KittenConfig extends Config {
             description = "Displays a countdown until your kitten leaves you for being underfed",
             position = 3
     )
-    default boolean kittenHungryOverlay() {
-        return true;
-    }
+    default boolean kittenHungryOverlay() { return true; }
 
     @ConfigItem(
             keyName = "kittenAttentionOverlay",
@@ -157,7 +153,6 @@ public interface KittenConfig extends Config {
             description = ""
     )
     void felineId(int id);
-
     @ConfigItem(
             keyName = "lastAttentionType",
             name = "",
@@ -174,6 +169,59 @@ public interface KittenConfig extends Config {
             description = ""
     )
     void lastAttentionType(KittenAttentionType lastAttentionType);
+
+
+    @ConfigItem(
+            keyName = "growthTicksAlive",
+            name = "growthTicksAlive",
+            description = "growthTicksAlive",
+            hidden = true
+    )
+    default int growthTicksAlive() {
+        return -1;
+    }
+
+    @ConfigItem(
+            keyName = "growthTicksAlive",
+            name = "growthTicksAlive",
+            description = "growthTicksAlive"
+    )
+    void growthTicksAlive(int ticks);
+
+
+    @ConfigItem(
+            keyName = "nextHungryTick",
+            name = "nextHungryTick",
+            description = "nextHungryTick",
+            hidden = true
+    )
+    default int nextHungryTick() {
+        return -1;
+    }
+
+    @ConfigItem(
+            keyName = "nextHungryTick",
+            name = "nextHungryTick",
+            description = "nextHungryTick"
+    )
+    void nextHungryTick(int ticks);
+
+    @ConfigItem(
+            keyName = "nextAttentionTick",
+            name = "nextAttentionTick",
+            description = "nextAttentionTick",
+            hidden = true
+    )
+    default int nextAttentionTick() {
+        return -1;
+    }
+
+    @ConfigItem(
+            keyName = "nextAttentionTick",
+            name = "nextAttentionTick",
+            description = "nextAttentionTick"
+    )
+    void nextAttentionTick(int ticks);
 
 }
 

--- a/src/main/java/com/kittentracker/KittenConfig.java
+++ b/src/main/java/com/kittentracker/KittenConfig.java
@@ -87,67 +87,6 @@ public interface KittenConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "secondsAlive",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int secondsAlive() {
-        return -1;
-    }
-
-    @ConfigItem(
-            keyName = "secondsAlive",
-            name = "",
-            description = ""
-    )
-    void secondsAlive(int seconds);
-
-    @ConfigItem(
-            keyName = "secondsHungry",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int secondsHungry() {
-        return -1;
-    }
-
-    @ConfigItem(
-            keyName = "secondsHungry",
-            name = "",
-            description = ""
-    )
-    void secondsHungry(int seconds);
-
-    @ConfigItem(
-            keyName = "secondsNeglected",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int secondsNeglected() {
-        return -1;
-    }
-
-    @ConfigItem(
-            keyName = "secondsNeglected",
-            name = "",
-            description = ""
-    )
-    void secondsNeglected(int seconds);
-
-    @ConfigItem(
-            keyName = "felineId",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int felineId() {
-        return -1;
-    }
-
-    @ConfigItem(
             keyName = "felineId",
             name = "",
             description = ""


### PR DESCRIPTION
Kitten mechanics that are now followed and tracked accordingly in this revision:
KITTEN GROWTH MECHANICS:
- Kitten grows one growth tick every 90s.
  - Upon reaching 90s, this growth tick does not progress if the player is in an interface (dialog, bank menu, etc.).
    - It will progress immediately after exiting that interface, as long as the kitten has a chance to grow
      (ex: growth does not progress if player AFKs to logout in a bank interface)
    - If you are only in an interface during a different time of that tick progress (ex: banking during seconds 40-70 of
      the 90s tick), the kitten's growth will be unaffected by you being in that interface, as long as you're not in an
      interface at 90s.
  - The kitten's progress within that 90s tick gets reset each time it is picked up, or when the player logs out/hops worlds.
- Kitten has overhead text each and every time it grows a growth tick, so as our as the timer ticks down,
   it waits for that overhead text before continuing to the next growth tick.  This is a much easier "catch-all" than
   checking for every kind of interface and hoping we don't miss any.
- Kitten can only request hunger/attention at the time when a growth tick progresses

DIALOG BOX TO CHECK AGE:
- Kitten's age in dialogue is not exact in minutes as shown in the dialog box.
  - As the kitten can only grow in increments of 90s, half of the ages shown in dialog is truncated.
  - Ex: If the dialog says your kitten is 1 minute old, it is really 1.5 minutes old.
    There is no dialog that will ever say it is 2 mins old - the increments shown to the player are
    0 minutes (0 growth ticks), 1 minute (1 growth tick, actually 1.5 mins), 3 minutes (2 growth ticks), 4 minutes
    (3 growth ticks, actually 4.5 mins), and so on.
  - The kitten has already progressed time inside of that growth tick when asked, so that time given is not exact either.
  - The adjustments made in this revision should now give you the exact growth progress your kitten has after pulling up the dialog.

ATTENTION TIMER:
- Kitten's attention requests (and run away time) are not 7 mins apart as shown on the wiki and previously in this plugin.
  - They are *supposed* to be 4.5 mins apart, but these can be delayed by a hunger notification which seems to always take precedence.  In this revision, I only changed the request timers to 4.5 mins apart instead of 7 mins, as well as changing the double stroke time to 22.5 mins until attention request (31.5 mins until run away).
  - If you want more of my notes on what still isn't accurate, I'll leave a little more detailed notes in the bottom of KittenPlugin.java.  Or message me on discord, firsttwoweeks
- Attention given for 2 or more strokes is always consistent at 22.5 mins (barring hunger notifications delaying it), but single stroke is variable based upon the time until the kitten runs away when you stroke it.  It's consistent though, so it's "solvable" - but again I didn't make those adjustments here.