### PR TITLE
Update Kitten Tracker to Properly Track Time as the In-Game Kitten Does

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
 # Kitten Tracker RuneLite plugin
 
-This plugins allows you to track the age of your pet kitten and shows how long before your kitten will leave you because of a lack of attention or when it is starving. It also shows notifications to remind you to feed your cat or give it attention. Clicking Guess Age updates the growth timer to the correct time if there is any offset.
+This plugin allows you to track the age of your pet kitten and shows how long before your kitten will leave you because of a lack of attention or when it is starving. It also shows notifications to remind you to feed your cat or give it attention. Clicking Guess Age updates the growth timer to the correct time if there is any offset.
 
+The plugin abides by the following kitten mechanics:
+- Kitten grows one growth tick every 90s.
+    - Upon reaching 90s, this growth tick does not progress if the player is in an interface (dialog, bank menu, etc.).
+        - Note: This does not include all interfaces.  If you can interact with the game while the interface is open (e.g. settings/world map is open, and you can still run around/skill/etc.), then that interface will not stall kitten growth.
+        - It will progress immediately after exiting that interface, as long as the kitten has a chance to grow (ex: growth does not progress if player AFKs to logout in a bank interface)
+        - If you are only in an interface during a different time of that tick progress (ex: banking during seconds 40-70 of the 90s tick), the kitten's growth will be unaffected by you being in that interface, as long as you're not in an interface at 90s.
+    - The kitten's progress within that 90s tick gets reset each time it is picked up, or when the player logs out/hops worlds.
+- Kitten has overhead text each and every time it grows a growth tick, so as our as the timer ticks down, it waits for that overhead text before continuing to the next growth tick.  This is a much easier "catch-all" than checking for every kind of interface and hoping we don't miss any.
+  - If you are at a very crowded place with many players/pets/etc., sometimes your kitten will not render.  This prevents the plugin from seeing the overhead text.  In this case, we will instead check for some common interfaces that would prevent growth.  Similarly, you can't see your kitten's overhead text if you teleport into a new area on the same tick.  
+    - This is not currently practical for the primary way to check growth, however, as there are likely hundreds of interfaces that pause growth (and hundreds more that do not pause growth) so it would be difficult to check for all of them.
+- Kitten can only request hunger/attention at the time when a growth tick progresses.
+
+Kitten's need for attention:
+- Kitten's attention requests (and run away time) are *supposed* to be 4.5 mins apart, but these can be delayed by a hunger notification which seems to always take precedence.  (As hunger notifications always take precedence, hunger notifications are always consistent no matter what.)
+  - Attention notifications can also be pushed back by upcoming hunger notifications, and not even ones that would coincide with the attention request time...  For example, see this chart of hunger and attention notifications:  https://i.imgur.com/6PFRJqB.png  You can easily replicate these results yourself as well.
+    - So if you keep your cat well-fed and never get notified of hunger, these notifications are consistently 4.5 mins apart.
+      - Your cat would also request attention every 22.5 minutes if stroked twice, or every 51 minutes if given a ball of wool.
+- Attention given for 2 or more strokes is always consistent at 22.5 mins until requesting attention again (barring hunger notifications delaying it).
+- Single-stroke mechanics add a variable time to the kitten requesting attention again.  It seems as if the more lonely your cat is (closer to running away), the less time a single stroke will add to its attention timer.  Single strokes can last as little at 7.5m before requesting attention again, but will last longer if you pet it before it's close to running away.
+    - A few data points I've gathered (ignoring hunger mechanics, as the kitten was well-fed during these times):
+        - Kitten is 1.5m from running away.
+            - Single stroke now takes 7.5m to request attention again (16.5m from running away)
+        - Kitten is 30m from running away (6m after double stroke).
+            - Single stroke now takes 21m to request attention again (30m from running away)
+        - Kitten is 31.5m from running away (4.5m after double stroke).
+            - Single stroke gives full amount of 22.5m to request attention again.
+        - I believe this can all be interpolated linearly, with it maxing out at 22.5 minutes until the next attention request.  Some testing (not very extensive) has shown this to be true so far.
+            - Formula would be:  Time until run away after stroked = Time until run away just before stroked + 15 mins, maxing out at 22.5 mins until requesting attention again.
+- IMPORTANT: many of these notes regarding the kitten's attention timer are not yet incorporated into the plugin, as it would require further testing.  I just wanted to include them here so that in case someone else wants to take my research/notes and go further with it.
+  - The current way the plugin behaves as is follows:
+    - Double stroke adds 36 minutes until the kitten runs away.  (Technically should be 31.5 mins, but more often than not hunger notifications will delay it to closer to 36m.)
+    - Single stroke adds 24 minutes until the kitten runs away (as mentioned above, it's actually variable).
+    - Ball of wool adds 60 minutes until the kitten runs away (accurate if hunger notifications do not interfere).
+    - Kitten warnings for attention are 9 minutes (first warning) and 4.5 minutes (second warning) until the kitten runs away.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.9.6'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/kittentracker/KittenAttentionType.java
+++ b/src/main/java/com/kittentracker/KittenAttentionType.java
@@ -23,6 +23,6 @@ public enum KittenAttentionType {
     }
 
     int getTimeBeforeKittenRunsAway() {
-        return attentionTime + KittenPlugin.ATTENTION_TIME_FROM_WARNING_TO_RUNNING_AWAY_IN_SECONDS;
+        return attentionTime + KittenPlugin.ATTENTION_FIRST_WARNING_TIME_LEFT_IN_SECONDS;
     }
 }

--- a/src/main/java/com/kittentracker/KittenConfig.java
+++ b/src/main/java/com/kittentracker/KittenConfig.java
@@ -86,6 +86,17 @@ public interface KittenConfig extends Config {
         return true;
     }
 
+
+    @ConfigItem(
+            keyName = "felineId",
+            name = "",
+            description = "",
+            hidden = true
+    )
+    default int felineId() {
+        return -1;
+    }
+
     @ConfigItem(
             keyName = "felineId",
             name = "",

--- a/src/main/java/com/kittentracker/KittenConfig.java
+++ b/src/main/java/com/kittentracker/KittenConfig.java
@@ -36,9 +36,7 @@ public interface KittenConfig extends Config {
             description = "Displays a countdown for your kitten to grow into a cat",
             position = 1
     )
-    default boolean kittenOverlay() {
-        return true;
-    }
+    default boolean kittenOverlay() { return true; }
 
     @ConfigItem(
             keyName = "catOverlay",
@@ -56,9 +54,7 @@ public interface KittenConfig extends Config {
             description = "Displays a countdown until your kitten leaves you for being underfed",
             position = 3
     )
-    default boolean kittenHungryOverlay() {
-        return true;
-    }
+    default boolean kittenHungryOverlay() { return true; }
 
     @ConfigItem(
             keyName = "kittenAttentionOverlay",
@@ -157,7 +153,6 @@ public interface KittenConfig extends Config {
             description = ""
     )
     void felineId(int id);
-
     @ConfigItem(
             keyName = "lastAttentionType",
             name = "",
@@ -174,6 +169,59 @@ public interface KittenConfig extends Config {
             description = ""
     )
     void lastAttentionType(KittenAttentionType lastAttentionType);
+
+
+    @ConfigItem(
+            keyName = "growthTicksAlive",
+            name = "growthTicksAlive",
+            description = "growthTicksAlive",
+            hidden = true
+    )
+    default int growthTicksAlive() {
+        return -1;
+    }
+
+    @ConfigItem(
+            keyName = "growthTicksAlive",
+            name = "growthTicksAlive",
+            description = "growthTicksAlive"
+    )
+    void growthTicksAlive(int ticks);
+
+
+    @ConfigItem(
+            keyName = "nextHungryTick",
+            name = "nextHungryTick",
+            description = "nextHungryTick",
+            hidden = true
+    )
+    default int nextHungryTick() {
+        return -1;
+    }
+
+    @ConfigItem(
+            keyName = "nextHungryTick",
+            name = "nextHungryTick",
+            description = "nextHungryTick"
+    )
+    void nextHungryTick(int ticks);
+
+    @ConfigItem(
+            keyName = "nextAttentionTick",
+            name = "nextAttentionTick",
+            description = "nextAttentionTick",
+            hidden = true
+    )
+    default int nextAttentionTick() {
+        return -1;
+    }
+
+    @ConfigItem(
+            keyName = "nextAttentionTick",
+            name = "nextAttentionTick",
+            description = "nextAttentionTick"
+    )
+    void nextAttentionTick(int ticks);
 
 }
 

--- a/src/main/java/com/kittentracker/KittenConfig.java
+++ b/src/main/java/com/kittentracker/KittenConfig.java
@@ -87,67 +87,6 @@ public interface KittenConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "secondsAlive",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int secondsAlive() {
-        return -1;
-    }
-
-    @ConfigItem(
-            keyName = "secondsAlive",
-            name = "",
-            description = ""
-    )
-    void secondsAlive(int seconds);
-
-    @ConfigItem(
-            keyName = "secondsHungry",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int secondsHungry() {
-        return -1;
-    }
-
-    @ConfigItem(
-            keyName = "secondsHungry",
-            name = "",
-            description = ""
-    )
-    void secondsHungry(int seconds);
-
-    @ConfigItem(
-            keyName = "secondsNeglected",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int secondsNeglected() {
-        return -1;
-    }
-
-    @ConfigItem(
-            keyName = "secondsNeglected",
-            name = "",
-            description = ""
-    )
-    void secondsNeglected(int seconds);
-
-    @ConfigItem(
-            keyName = "felineId",
-            name = "",
-            description = "",
-            hidden = true
-    )
-    default int felineId() {
-        return -1;
-    }
-
-    @ConfigItem(
             keyName = "felineId",
             name = "",
             description = ""

--- a/src/main/java/com/kittentracker/KittenPlugin.java
+++ b/src/main/java/com/kittentracker/KittenPlugin.java
@@ -493,7 +493,7 @@ public class KittenPlugin extends Plugin {
         will likely freeze for a few seconds at the end of the current growth tick upon returning to a low-population
         area, if you spent a long time in a high population area.  This is better than the alternative - if it moves
         too quickly it will likely freeze for a full growth tick upon returning to the other method.
-        (Instead of advancing after secondsInTick >=89, I tried 89.5s, but that was too quick.)
+        (Instead of advancing after secondsInTick >=89, I tried 88.5s, but that was too quick.)
          */
         HashTable<WidgetNode> componentTable = client.getComponentTable();
         boolean stallingInterfaceOpen = false;


### PR DESCRIPTION
Kitten mechanics that are now followed and tracked accordingly in this revision:

KITTEN GROWTH MECHANICS:
- Kitten grows one growth tick every 90s.
      - Upon reaching 90s, this growth tick does not progress if the player is in an interface (dialog, bank menu, etc.).
            -   - It will progress immediately after exiting that interface, as long as the kitten has a chance to grow (ex: growth does not progress if player AFKs to logout in a bank interface)
            -   - If you are only in an interface during a different time of that tick progress (ex: banking during seconds 40-70 of the 90s tick), the kitten's growth will be unaffected by you being in that interface, as long as you're not in an interface at 90s.
      - The kitten's progress within that 90s tick gets reset each time it is picked up, or when the player logs out/hops worlds.
 - Kitten has overhead text each and every time it grows a growth tick, so as our as the timer ticks down, it waits for that overhead text before continuing to the next growth tick. This is a much easier "catch-all" than checking for every kind of interface and hoping we don't miss any.
      - However… there are a few exceptions in which you cannot see the kitten’s overhead text.  When you are in a very high population area (ex: shooting stars), the kitten sometimes will not render, meaning you can’t see its overhead text.  Also, when you teleport on the same tick as when a growth tick advances, you can’t see your kitten’s overhead text either (maybe it’s similarly not rendered in that moment).  In these cases, we instead check to make sure that the player is not in any common interfaces that would stall growth.  It’s not all inclusive, but it’s a good “compromise” kind of work around.
 - Kitten can only request hunger/attention at the time when a growth tick progresses

DIALOG BOX TO CHECK AGE:
 - Kitten's age in dialogue is not exact in minutes as shown in the dialog box.
      - As the kitten can only grow in increments of 90s, half of the ages shown in dialog is truncated.
      - Ex: If the dialog says your kitten is 1 minute old, it is really 1.5 minutes old.
There is no dialog that will ever say it is 2 mins old - the increments shown to the player are
0 minutes (0 growth ticks), 1 minute (1 growth tick, actually 1.5 mins), 3 minutes (2 growth ticks), 4 minutes
(3 growth ticks, actually 4.5 mins), and so on.
      - The kitten has already progressed time inside of that growth tick when asked, so that time given is not exact either.
      - The adjustments made in this revision should now give you the exact growth progress your kitten has after pulling up the dialog.

ATTENTION TIMER:
 - Kitten's attention requests (and run away time) are not 7 mins apart as shown on the wiki and previously in this plugin.
      - They are supposed to be 4.5 mins apart, but these can be delayed by a hunger notification which seems to always take precedence. In this revision, I only changed the request timers to 4.5 mins apart instead of 7 mins, as well as changing the double stroke time to 36 mins until run away (this is technically inaccurate, but is probably the most common case, read the README for details).
    - If you want more of my notes on what still isn't accurate, I’ll leave the notes in the README. Or message me on discord, firsttwoweeks
- Attention given for 2 or more strokes is always consistent at 22.5 mins (barring hunger notifications delaying it), but single stroke is variable based upon the time until the kitten runs away when you stroke it. It's consistent though, so it's "solvable" - but again I didn't make those adjustments here.

Known issues at this time (they're minor, but I wasn't able to find a way to eliminate them just yet):
- When spending a long time in a high population area, the timer runs slightly quickly.  This adds up over time, and upon returning to a low population area, the timer will likely pause for a few seconds.  With the way it operates, it's better than the alternative of running a tick slower, which was the only other option I could see. (Running slightly slowly causes the timer to freeze for much longer and miss a growth tick entirely upon returning to a low population area.)
- If you afk to logout in an interface while in a high population area (ex: kitten requests hunger while you're at a star, you leave that dialog up and afk to logout), the plugin will advance a growth tick, when it should not.  This behavior is tracked properly in the overhead text method of tracking growth ticks, as the kitten will not have any overhead text, but it would have to be circumvented differently here.