### PR TITLE
Removed references to the poll booth InterfaceIDs that were deleted

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.kittentracker'
-version = '1.2'
+version = '1.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/kittentracker/KittenPlugin.java
+++ b/src/main/java/com/kittentracker/KittenPlugin.java
@@ -179,7 +179,7 @@ public class KittenPlugin extends Plugin {
             InterfaceID.CA_OVERVIEW, InterfaceID.CA_TASKS,
             InterfaceID.CA_BOSSES, InterfaceID.CA_REWARDS, InterfaceID.CRM_SURPRISEPOPUP_SIDE,
             InterfaceID.DISPLAYNAME, // believe it or not this does pause kitten growth
-			InterfaceID.POLL_RESULTS, InterfaceID.POLL_HISTORY, InterfaceID.FAVOUR_KEYRING,
+			InterfaceID.FAVOUR_KEYRING,
             InterfaceID.BOOKOFSCROLLS,
 			InterfaceID.FORESTRY_KIT_MAIN, InterfaceID.FORESTRY_KIT_SIDE, // forestry main and side simultaneously open
 			InterfaceID.GE_OFFERS, InterfaceID.BANK_DEPOSITBOX, InterfaceID.GE_COLLECT,


### PR DESCRIPTION
We don't need to add the new Ballot InterfaceID as it does not stall kitten growth.